### PR TITLE
Restore test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@8ebefb139a87a89d290266970bc401009cda6508
+        uses: Homebrew/actions/setup-homebrew@67c851794cd9f6000e4047cf2a47b023540ac1be
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@8ebefb139a87a89d290266970bc401009cda6508
+        uses: Homebrew/actions/git-user-config@67c851794cd9f6000e4047cf2a47b023540ac1be
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
@@ -52,8 +52,8 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-#      - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
-#        if: github.event_name == 'pull_request'
+      - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
+        if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,16 +52,17 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-        with:
-          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
-          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
+#      - name: Generate token
+#        id: generate_token
+#        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+#        with:
+#          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
+#          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
 
       - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
         env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
+#          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         with:
           app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
           private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,16 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
+          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
+
       - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,16 +52,8 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-#      - name: Generate token
-#        id: generate_token
-#        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
-#        with:
-#          app_id: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_ID }}
-#          private_key: ${{ secrets.GH_PROJECT_MANAGEMENT_APP_PEM }}
-
       - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
         env:
-#          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.generate_token.outputs.token }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request'
 


### PR DESCRIPTION
## Issue
During the preview 9 release, we ran into the following error during the test run:
```sh
brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
==> Using Homebrew/homebrew-test-bot 7d0f680 (Merge pull request #922 from carlocab/download-previously-built-bottles)
==> Using Homebrew/brew [4](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:5).0.19-24-ge96fd24a7 (Merge pull request #15481 from reitermarkus/sudo-xattrs)
==> Testing stellar/homebrew-tap fa6c03e (Merge 2b6b370e9669c0b6a[5](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:6)26c5349cdd01dcdbcd683b into ab2cfa753455144b8df308f90ae254b390dfc515):

==> Running FormulaeDetect#detect_formulae!
==> git -C /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/stellar/homebrew-tap fetch origin +refs/heads/main
    url               https://github.com/stellar/homebrew-tap/pull/19/checks
    tap origin/main ab2cfa7 (update homebrew 0.8.0 (#20))
    HEAD              fa[6](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:7)c03e (Merge 2b6b370e9669c0b6a526c5349cdd01dcdbcd683b into ab2cfa753455144b8df308f90ae254b390dfc515)
    diff_start_sha1   ab2cfa753455144b8df308f90ae254b390dfc515
    diff_end_sha1     fa6c03e2c362a58b085aafe8ba6940e162edf807

    testing_formulae  stellar/tap/stellar-core-futurenet stellar/tap/stellar-xdr
    added_formulae    (none)
    modified_formulae stellar/tap/stellar-core-futurenet stellar/tap/stellar-xdr
    deleted_formulae  (none)
==> git -C /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/stellar/homebrew-tap fetch origin 9c6e8b8[7](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:8)47ea43b4697a[8](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:9)[10](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:11)d38de07888f6f3e[11](https://github.com/stellar/homebrew-tap/actions/runs/5084939960/jobs/9137860815#step:9:12)
Error: GitHub API Error: This endpoint requires you to be authenticated.
The GitHub credentials in the macOS keychain may be invalid.
Clear them with:
  printf "protocol=https\nhost=github.com\n" | git credential-osxkeychain erase
Create a GitHub personal access token:
https://github.com/settings/tokens/new?scopes=gist,repo,workflow&description=Homebrew
echo 'export HOMEBREW_GITHUB_API_TOKEN=your_token_here' >> ~/.profile

Error: Process completed with exit code 1.
```

## Why ?
Apparently, the GitHub changes their policy regarding the search api, which now requires authorization.
As a temporary measure, we disabled the test; This PR intend to bring it back and fix the required authorization.

## Solution
Pass the GitHub API key to HOMEBREW_GITHUB_API_TOKEN, so that brew could use it.