### PR TITLE
rollback disabling-test for v20.0.0-rc.4.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,8 +55,7 @@ jobs:
       - run: brew test-bot --only-formulae --root-url 'https://ghcr.io/v2/stellar/homebrew-tap'
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # temporary disable for v20.0.0-rc.4.1
-        if: github.event_name == 'pull_request' && 1 == 0
+        if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'


### PR DESCRIPTION
when upgrading from `v20.0.0-rc4` to `v20.0.0-rc.4.1`, the test was complaining that we're "downgrading" the versions, which wasn't true.
To work around that, I disabled the test on https://github.com/stellar/homebrew-tap/pull/33, however, now that it got merged and deployed, I'd like to rollback the change.