### PR TITLE
Fix the publish event type

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: brew pr-pull
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 


### PR DESCRIPTION
### What
Change the publish event trigger to pull_request_target.

### Why
The target variant is recommended by homebrew for this job so the job runs from the main branch and pulls in the pr.